### PR TITLE
Remove default for webhook and treat it like token

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,10 +20,11 @@ class PlaidAuthenticator extends Component {
       publicKey
     }&apiVersion=v2&env=${env}&product=${product}&clientName=${
       clientName
-    }&isWebView=true&isMobile=true&webhook=${webhook}&selectAccount=${
+    }&isWebView=true&isMobile=true&selectAccount=${
       selectAccount
     }`;
     uri = token !== undefined ? `${uri}&token=${token}` : uri;
+    uri = webhook !== undefined ? `${uri}&webhook=${webhook}` : uri;
 
     return (
       <WebView
@@ -80,7 +81,6 @@ PlaidAuthenticator.defaultProps = {
 
 PlaidAuthenticator.defaultProps = {
   clientName: '',
-  webhook: '',
   plaidRef: () => {}
 };
 


### PR DESCRIPTION
Using empty string as a default for webhook causes the following response to be returned by Plaid when Link posts to `/create`
```
{
  "display_message": null,
  "error_code": "INVALID_FIELD",
  "error_message": "options.webhook must be a non-empty string URL",
  "error_type": "INVALID_REQUEST",
  "request_id": "P16N3"
}
```

This change removes the default and only adds `webhook` to the query string if it exists, mirroring how `token` is handled.

Let me know what you think and thanks for building this!