### PR TITLE
Move native webview to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "React Native Plaid Link Webview authenticator",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "homepage": "https://github.com/catalinmiron/react-native-plaid-link#readme",
   "peerDependencies": {
     "prop-types": "^15.6.0",
-    "react-native": ">= 0.20.0"
+    "react-native": ">= 0.20.0",
+    "react-native-webview": "^5.3.0"
   },
   "dependencies": {
     "object.omit": "^3.0.0",
-    "react-native-webview": "^5.3.0"
   }
 }


### PR DESCRIPTION
Can we move `react-native-webview` to peer depencencies? Currently getting some issues where 2 versions of the package get installed due to different versions in my projects' `package.json` and the one in the library